### PR TITLE
Fix for PHP notices about undefined Session-Token index

### DIFF
--- a/src/Glpi/Api/Rest/Client.php
+++ b/src/Glpi/Api/Rest/Client.php
@@ -133,12 +133,14 @@ class Client {
       $apiToken = $this->addTokens();
       try {
          $options['headers']['Content-Type'] = "application/json";
-         if ($apiToken) {
+         $sessionHeaders = [];
+         if ($apiToken and key_exists('Session-Token', $apiToken)) {
             $sessionHeaders = ['Session-Token' => $apiToken['Session-Token']];
-            if (key_exists('App-Token', $apiToken)) {
-               $sessionHeaders['App-Token'] = $apiToken['App-Token'];
-            }
-            $options = array_merge_recursive($options, ['headers' => $sessionHeaders]);
+         }
+         if (key_exists('App-Token', $apiToken)) {
+            $sessionHeaders['App-Token'] = $apiToken['App-Token'];
+         }
+         $options = array_merge_recursive($options, ['headers' => $sessionHeaders]);
          }
          $response = $this->httpClient->request($method, $this->url . $uri, $options);
          return $response;


### PR DESCRIPTION
### Changes description

It resolves the issue that caused *Undefined index: Session-Token* PHP notices.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Closes #65